### PR TITLE
CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 
 # Changelog
 
+## Version 0.2.3 (2021-5-11)
+
+- Adds a rudimentary CLI
+- Removes `requests_html` as dependency and improves download performance
+- Adds `tqdm` progressbar support to `upload` and `download`
+
+```bash
+# get help
+anonfile [download|upload] --help
+
+# 1. enable verbose for progressbar feedback, else run silent
+# 2. both methods expect at least one argument
+
+anonfile --verbose download --url https://anonfiles.com/93k5x1ucu0/test_txt
+
+anonfile --verbose upload --file ./test.txt
+```
+
+## Version 0.2.2 (2021-5-05)
+
+- **NOTE** Version `0.2.1` was skipped due to a technical mistake
+- Unit Tests are now compatible with Python 3.7
+- Upgrades `importlib-metadata` dependency to version 4.0.1 in `requirements/release.txt`
+- Fixes an error in `setup.py`
+
 ## Version 0.2.0 (2021-05-04)
 
 - **IMPORTANT:** This is a major update to the client-facing library interface

--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ Add the `-k test_*` option if you want to test only a single function.
 ## Usage
 
 Import the module and instantiate the `AnonFile()` constructor. Setting the download
-directory in `path` is optional.
+directory in `path` is optional. Using the API `token` in the constructor is optional
+as well. A valid `token` registers all file uploads online, i.e. a list of all uploaded
+files is made accessible to any user that [signs into your account](https://anonfiles.com/login).
 
 ```python
 from anonfile import AnonFile
 
-anon = AnonFile('api_key')
+anon = AnonFile()
 
 # upload a file and enable progressbar terminal feedback
 upload = anon.upload('/home/guest/jims_paperwork.doc', progressbar=True)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ And have fun!
 Run unit tests locally:
 
 ```bash
-pytest --verbosity=2 -s --token "REDACTED"
+pytest --verbosity=2 -s [--token "REDACTED"]
 ```
 
 Add the `-k test_*` option if you want to test only a single function.
@@ -58,13 +58,12 @@ from anonfile import AnonFile
 
 anon = AnonFile('api_key')
 
-# uploading a file
-upload = anon.upload('/home/guest/jims_paperwork.doc')
+# upload a file and enable progressbar terminal feedback
+upload = anon.upload('/home/guest/jims_paperwork.doc', progressbar=True)
 print(upload.url.geturl())
 
-# downloading a file
+# download a file and set the download directory
 from pathlib import Path
-
 target_dir = Path.home().joinpath('Downloads')
 filename = anon.download("https://anonfiles.com/9ee1jcu6u9/test_txt", path=target_dir)
 print(filename)
@@ -73,9 +72,24 @@ print(filename)
 And voilà, pain-free anonymous file sharing. If you want more information about
 the `AnonFile` API visit [anonfiles.com](https://anonfiles.com/docs/api).
 
+## Command Line Interface
+
+```bash
+# get help
+anonfile [download|upload] --help
+
+# 1. enable verbose for progress bar feedback, else run silent
+# 2. both methods expect at least one argument
+
+anonfile --verbose download --url https://anonfiles.com/93k5x1ucu0/test_txt
+
+anonfile --verbose upload --file ./test.txt
+```
+
 ## Built With
 
 * [Requests](http://docs.python-requests.org/en/master/) - Http for Humans
+* [TQDM](https://github.com/tqdm/tqdm) - Fast & Extensible Progress Bars
 * [anonfiles.com](https://anonfiles.com/docs/api) - AnonFiles.com REST API
 
 ## Versioning

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,4 +1,3 @@
 requests==2.25.1
-requests_html==0.10.0
 faker==8.1.2
 importlib-metadata==4.0.1

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,3 +1,4 @@
 requests==2.25.1
+tqdm==4.60.0
 faker==8.1.2
 importlib-metadata==4.0.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     project_urls={
         'Source Code': "https://github.com/nstrydom2/anonfile-api",
         'Bug Reports': "https://github.com/nstrydom2/anonfile-api/issues",
-        'Changelog': "https://github.com/nstrydom2/anonfile-api/blob/master/changelog"
+        'Changelog': "https://github.com/nstrydom2/anonfile-api/blob/master/CHANGELOG.md"
     },    
     python_requires=">=%d.%d" % (python_major, python_minor),
     install_requires=packages,
@@ -44,9 +44,13 @@ setup(
     },
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
+    entry_points={
+        'console_scripts': ['%s=%s.__init__:main' % (package_name, package_name)]
+    },
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/src/anonfile/__init__.py
+++ b/src/anonfile/__init__.py
@@ -1,3 +1,40 @@
 #!/usr/bin/env python3
 
+import argparse
+from pathlib import Path
+
 from .anonfile import *
+from .anonfile import __version__
+
+def main():
+    parser = argparse.ArgumentParser(prog=package_name)
+    subparser = parser.add_subparsers(dest='command')
+
+    parser.add_argument('--version', action='version', version=f"%(prog)s {__version__}")
+    parser.add_argument('--verbose', action='store_true', help="increase output verbosity")
+    parser.add_argument('--token', type=str, default='secret', help="configure an API token (optional)")
+
+    upload_parser = subparser.add_parser('upload', help="upload a file to https://anonfiles.com")
+    upload_parser.add_argument('--file', nargs='+', type=Path, help="one or more file to upload.")
+
+    download_parser = subparser.add_parser('download', help="download a file from https://anonfiles.com")
+    download_parser.add_argument('--url', nargs='+', type=str, help="one or more URL to download")
+    download_parser.add_argument('--path', type=Path, default=Path.cwd(), help="download directory (CWD by default)")
+
+    args = parser.parse_args()
+
+    anon = AnonFile(args.token)
+
+    if args.command == 'upload':
+        for file in args.file:
+            upload = anon.upload(file, progressbar=args.verbose)
+            print(f"URL: {upload.url.geturl()}")
+
+    if args.command == 'download':
+        for url in args.url:
+            download = anon.download(url, args.path, progressbar=args.verbose)
+            print(f"File: {download.file_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--token',
         action='append',
-        default=None,
+        default=["REDACTED"],
         help="Secret anonfiles.com API token."
     )
 

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -5,14 +5,15 @@ from pathlib import Path
 
 from src.anonfile import AnonFile
 
+TOKEN = None
+
 def test_option(token):
-    global TOKEN
     TOKEN = token
 
 
 class TestAnonFile(unittest.TestCase):
     def setUp(self):
-        self.anon = AnonFile(TOKEN)
+        self.anon = AnonFile(TOKEN) if TOKEN else AnonFile()
         self.test_file = Path("tests/test.txt")
         self.test_path = "https://anonfiles.com/93k5x1ucu0/test_txt"
 

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -18,12 +18,12 @@ class TestAnonFile(unittest.TestCase):
         self.test_path = "https://anonfiles.com/93k5x1ucu0/test_txt"
 
     def test_upload(self):
-        result = self.anon.upload(self.test_file)
+        result = self.anon.upload(self.test_file, progressbar=True)
         self.assertTrue(result.status, msg="Expected 200 HTTP Error Code")
         self.assertTrue(all([result.url.scheme, result.url.netloc, result.url.path]), msg="Invalid URL.")
 
     def test_download(self):
-        result = self.anon.download(self.test_path)
+        result = self.anon.download(self.test_path, progressbar=True)
         self.assertTrue(result.file_path.exists(), msg="Download not successful.")
         self.assertEqual(result.file_path.name, self.test_file.name, msg="Different file in download path detected.")
         result.file_path.unlink()


### PR DESCRIPTION
Unbeknownst to me, it turns out that `requests_html` does add `BeautfilSoup4` and `lxml` (amongst a few other things) as indirect dependencies to the project, both of which are heavy libraries. We only use it in one line to retrieve the download link from the website. Therefore, I rewrote this section by using regular expressions which is much faster. It's relatively safe to use in this case, and even if it should break in the future, it is easy enough to fix with all the benefits that stem from using it.

Additionally, I also made a few changes to `setup.py`:
- fix the URL to the change log
- defines an entry point for the application (CLI)
- adds Python 3.9 to the list of classifiers

I used `argparse` and sub parsers to create the CLI:

```bash
# get help
anonfile [download|upload] --help

# 1. enable verbose for progress bar feedback, else run silent
# 2. both methods expect at least one argument

anonfile --verbose download --url https://anonfiles.com/93k5x1ucu0/test_txt
anonfile --verbose upload --file ./test.txt
```

Progress bars are turned off by default for scripting purposes. Downloading and uploading text files is a rather fast process, so it's up to the end user to consciously turn on this feature. They're also turned on in the test suite so that any mistakes should be caught by the CI scripts in case there're some incompatibilities with other versions of python. I tested and developed this PR under version 3.8.