### PR TITLE
Add logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://github.com/nstrydom2/anonfile-api" title="Project Logo">
+    <img height="150" style="margin-top:15px" src="https://raw.githubusercontent.com/nstrydom2/anonfile-api/master/logo.svg">
+  </a>
+</p>
+
 # Anonfiles.com Unofficial Python API
 
 [![PyPI version shields.io](https://img.shields.io/pypi/v/anonfile)](https://pypi.python.org/pypi/anonfile/)

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="160.01901"
+   height="125.52962"
+   viewBox="0 0 42.338362 33.213045"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1 (c4e8f9ed74, 2021-05-24)"
+   sodipodi:docname="anonfile-logo.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title191974">anonfiles Logo</title>
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="px"
+     showgrid="false"
+     inkscape:zoom="2.8284272"
+     inkscape:cx="103.41436"
+     inkscape:cy="102.70726"
+     inkscape:window-width="1918"
+     inkscape:window-height="1062"
+     inkscape:window-x="1920"
+     inkscape:window-y="16"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     units="px"
+     width="500px"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-grids="false"
+     inkscape:snap-smooth-nodes="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid29"
+       originx="-44.97665"
+       originy="-49.539312" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient142338">
+      <stop
+         style="stop-color:#ececec;stop-opacity:1"
+         offset="0"
+         id="stop142334" />
+      <stop
+         style="stop-color:#ececec;stop-opacity:1"
+         offset="1"
+         id="stop142336" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient25705">
+      <stop
+         style="stop-color:#4e4e4e;stop-opacity:1"
+         offset="0"
+         id="stop25701" />
+      <stop
+         style="stop-color:#363636;stop-opacity:1"
+         offset="1"
+         id="stop25703" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient25705"
+       id="linearGradient83239"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-123.71279,77.200144)"
+       x1="89.549339"
+       y1="29.834576"
+       x2="104.10143"
+       y2="15.282492" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient142338"
+       id="linearGradient142340"
+       x1="19.512644"
+       y1="95.007675"
+       x2="35.903236"
+       y2="105.84367"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(-44.976651,-49.53931)">
+    <g
+       id="g191970"
+       transform="translate(30.427083,-37.368478)">
+      <rect
+         style="display:inline;opacity:1;fill:url(#linearGradient83239);fill-opacity:1;fill-rule:evenodd;stroke-width:0.257649"
+         id="rect83219"
+         width="14.552082"
+         height="14.552083"
+         x="-34.163448"
+         y="92.482635"
+         ry="0.52916682"
+         transform="rotate(-35.470411)" />
+      <path
+         id="path83221"
+         style="display:inline;opacity:1;fill:url(#linearGradient142340);fill-opacity:1;fill-rule:evenodd;stroke-width:0.162277"
+         d="m 31.728209,99.072178 c -0.238752,0.170114 -0.29401,0.499274 -0.123895,0.738027 4.298926,6.033465 0,0 4.298926,6.033465 8.619228,-6.141327 0,0 8.619228,-6.141327 -4.298926,-6.03346 0,0 -4.298926,-6.03346 -0.170114,-0.238753 -0.499274,-0.29401 -0.738027,-0.123896 z"
+         sodipodi:nodetypes="sccccss" />
+      <path
+         id="path83223"
+         style="display:inline;opacity:1;fill:#2b2b2b;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0573741"
+         d="m 27.458922,93.992223 c 2.763595,3.878653 0,0 2.763595,3.878653 0.170115,0.238753 0.499275,0.29401 0.738028,0.123896 1.185144,-0.844432 0,0 1.185144,-0.844432 -3.070661,-4.309615 -5e-6,-2e-6 -3.070661,-4.309615 -1.616106,1.151498 0,0 -1.616106,1.151498 z"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         id="path83225"
+         style="display:inline;opacity:1;fill:#ececec;fill-opacity:1;fill-rule:evenodd;stroke-width:0.119434"
+         d="m 29.075028,92.840725 c 3.070661,4.309615 0,0 3.070661,4.309615 6.572164,-4.68276 0,0 6.572164,-4.68276 0.238754,-0.170116 0.294004,-0.499272 0.123889,-0.738024 -2.763595,-3.878653 0,0 -2.763595,-3.878653 -7.003119,4.989822 0,0 -7.003119,4.989822 z"
+         sodipodi:nodetypes="cccccc" />
+      <rect
+         style="display:inline;opacity:1;fill:#2b2b2b;fill-opacity:1;fill-rule:evenodd;stroke-width:0.0463752"
+         id="rect83227"
+         width="1.8520867"
+         height="3.7041667"
+         x="-25.961361"
+         y="93.011803"
+         ry="0.52916819"
+         transform="rotate(-35.470411)" />
+      <circle
+         style="display:inline;opacity:1;fill:#ececec;fill-opacity:1;stroke-width:0.198437"
+         id="circle83229"
+         cx="-20.60355"
+         cy="106.04253"
+         r="0.39687499"
+         transform="rotate(-35.470411)" />
+      <path
+         style="display:inline;opacity:1;fill:#e5e5e5;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 39.158333,120.12083 c 3.915271,-10.79143 1.322916,-15.08125 1.322916,-15.08125 l -10.054166,0.79375 c 0,0 -3.120824,7.62442 1.852083,14.2875 z"
+         id="path115720"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path83287"
+         style="display:inline;opacity:1;fill:#262626;fill-opacity:1;stroke:none;stroke-width:0.265623px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 35.374069,104.78533 c 0,0 -2.289911,2.89267 -2.438096,4.10679 0,0 0.81778,-0.97854 1.61489,-1.63229 0,0 1.061037,-0.0179 0.568957,2.0198 0,0 -1.179883,3.07508 -1.146183,10.8412 3.519681,0 0,0 3.519681,0 0.0337,-7.76612 -1.146183,-10.8412 -1.146183,-10.8412 -0.49208,-2.03773 0.568957,-2.0198 0.568957,-2.0198 l 1.353529,1.85859 c 0.05101,-1.86958 -2.177251,-4.33309 -2.177251,-4.33309 z"
+         sodipodi:nodetypes="ccccccccccc" />
+      <path
+         id="path109848"
+         style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 117.43569,387.334 c 0,0 -5.01964,6.43791 -4.07436,9.44725 0.94527,3.00934 7.01666,12.38142 11.12109,14.6582 0.56007,-4.55293 9.21485,-15.40039 9.21485,-15.40039 -8.57573,0.81513 -16.26158,-8.70506 -16.26158,-8.70506 z"
+         sodipodi:nodetypes="csccc"
+         transform="scale(0.26458333)" />
+      <path
+         id="path125787"
+         style="display:inline;opacity:1;fill:#262626;fill-opacity:1;stroke:none;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 117.43572,387.33404 c 0,0 -10.63151,5.67703 -14.47088,11.24994 -3.839365,5.57292 -20.779695,6.14062 -32.707028,8.93164 -11.378827,2.66272 -16.375417,26.97703 -15.0625,46.08594 L 122,454 c -18.61731,-24.94489 -7.2526,-53.3648 -7.03516,-53.90234 -0.78813,-1.36891 -1.36285,-2.55025 -1.60351,-3.31641 -0.94528,-3.00934 4.07439,-9.44721 4.07439,-9.44721 z"
+         sodipodi:nodetypes="csscccsc"
+         transform="scale(0.26458333)" />
+      <path
+         id="path128696"
+         style="display:inline;opacity:1;fill:#262626;fill-opacity:1;stroke:none;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 152.75391,387.88672 -0.48243,0.34375 c 1.1684,1.46226 2.95801,4.13462 2.30274,6.2207 -0.2138,0.68066 -0.63704,1.8635 -1.19922,3.29102 1.6302,3.51963 7.65308,20.34926 -5.375,56.25781 l 66.80469,-0.39844 c 1.31291,-19.10891 -3.68368,-43.4232 -15.0625,-46.08594 -11.92733,-2.79102 -28.86766,-3.35872 -32.70703,-8.93164 -3.13347,-4.54828 -11.27334,-9.10756 -14.28125,-10.69726 z"
+         transform="scale(0.26458333)" />
+      <path
+         id="path138241"
+         style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 40.277644,102.7069 c 0,0 -1.773556,1.53591 -4.185274,2.07843 0.06167,0.068 2.216565,2.45802 2.166276,4.28656 1.085966,-0.6024 2.378162,-3.92286 2.628265,-4.7191 0.250105,-0.79621 -0.609267,-1.64589 -0.609267,-1.64589 z"
+         sodipodi:nodetypes="cccsc" />
+    </g>
+  </g>
+  <metadata
+     id="metadata191972">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>anonfiles Logo</dc:title>
+        <dc:date>2021/08/18</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>hentai-chan</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source>www.github.com/hentai-chan</dc:source>
+        <dc:description>anonfiles logo (https://anonfiles.com/)</dc:description>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>


### PR DESCRIPTION
Closes #53 

I took the liberty to convert the logo from <https://www.anonfiles.com> into a SVG file. It's not a 1:1 copy; a few details were removed and/or modified, but by and large it stays truthful to the original design.

![anonfile logo](https://raw.githubusercontent.com/nstrydom2/anonfile-api/logo/logo.svg)

The README.md file links the image as if it were already merged to master, otherwise, the logo wouldn't be rendered outside of GitHub using relative image paths (think for example on https://www.pypi.org/project/anonfile>).