### PR TITLE
revision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+venv1/
 ENV/
 env.bak/
 venv.bak/
@@ -133,6 +134,8 @@ dmypy.json
 
 # untracked dev files
 test-*.py
+test.txt
+topsecret.mkv
 
 # intelliJ’s project specific settings files
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.2.7 (2021-8-31)
+## Version 0.2.7 (2021-9-12)
 
 Makes further improvements to the CLI:
 
@@ -9,8 +9,11 @@ Makes further improvements to the CLI:
   with the `--no-check` method. It's enabled by default and may require further
   user-input in case the target directory contains a file with the same name as
   the issued download command
+- further adds a `--user-agent` and `--proxies` flag to the CLI; these fields were also
+  added to the `AnonFile` constructor
 - implements a preview command to obtain meta data without committing to a time-
   consuming download
+- commands related to the log file were also added to the CLI
 
 As for the main library, the following changes have been added since the last release:
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ the `AnonFile` API visit [anonfiles.com](https://anonfiles.com/docs/api).
 ## Command Line Interface
 
 ```bash
-# get help
-anonfile [download|upload] --help
+# open help page for specific commands
+anonfile [download|upload|preview|log] --help
 
 # note: both methods expect at least one argument, but can take on more
 anonfile download --url https://anonfiles.com/93k5x1ucu0/test_txt

--- a/src/anonfile/__init__.py
+++ b/src/anonfile/__init__.py
@@ -33,7 +33,7 @@ def main():
     parser.add_argument('-l', '--logging', default=True, action='store_true', help="enable URL logging (default)")
     parser.add_argument('--no-logging', dest='logging', action='store_false', help="disable all logging activities")
     parser.add_argument('-t', '--token', type=str, default='secret', help="configure an API token (optional)")
-    parser.add_argument('-a', '--user-agent', type=str, help="configure custom User-Agent (optional)")
+    parser.add_argument('-a', '--user-agent', type=str, default=None, help="configure custom User-Agent (optional)")
 
     subparser = parser.add_subparsers(dest='command')
     upload_parser = subparser.add_parser('upload', help="upload a file to https://anonfiles.com")
@@ -56,7 +56,7 @@ def main():
 
     try:
         args = parser.parse_args()
-        anon = AnonFile(args.token)
+        anon = AnonFile(args.token, user_agent=args.user_agent)
 
         if args.command is None:
             raise UserWarning("missing a command")

--- a/src/anonfile/__init__.py
+++ b/src/anonfile/__init__.py
@@ -22,6 +22,10 @@ def __from_file(path: Path) -> List[str]:
         return [line.rstrip() for line in file_handler.readlines() if line[0] != '#']
 
 
+def format_proxies(proxies: str) -> dict:
+    return {prot: f"{prot}://{ip}" for (prot, ip) in [proxy.split('://') for proxy in proxies.split()]}
+
+
 def main():
     parser = argparse.ArgumentParser(prog=package_name)
     parser._positionals.title = 'Commands'
@@ -34,6 +38,7 @@ def main():
     parser.add_argument('--no-logging', dest='logging', action='store_false', help="disable all logging activities")
     parser.add_argument('-t', '--token', type=str, default='secret', help="configure an API token (optional)")
     parser.add_argument('-a', '--user-agent', type=str, default=None, help="configure custom User-Agent (optional)")
+    parser.add_argument('-p', '--proxies', type=str, default=None, help="configure HTTP and/or HTTPS proxies (optional)")
 
     subparser = parser.add_subparsers(dest='command')
     upload_parser = subparser.add_parser('upload', help="upload a file to https://anonfiles.com")
@@ -56,7 +61,7 @@ def main():
 
     try:
         args = parser.parse_args()
-        anon = AnonFile(args.token, user_agent=args.user_agent)
+        anon = AnonFile(args.token, user_agent=args.user_agent, proxies=format_proxies(args.proxies) if args.proxies else None)
 
         if args.command is None:
             raise UserWarning("missing a command")

--- a/src/anonfile/__init__.py
+++ b/src/anonfile/__init__.py
@@ -12,12 +12,14 @@ from .anonfile import *
 from .anonfile import __version__
 
 
-def __print_dict(dictionary: dict, indent: int=4) -> None:
-    print("{\n%s\n}" % '\n'.join([f"\033[36m{indent*' '}{key}\033[0m: \033[32m{value}\033[0m" for key, value in dictionary.items()]))
+def __print_dict(dictionary: dict, indent: int = 4) -> None:
+    print("{\n%s\n}" % '\n'.join([f"\033[36m{indent * ' '}{key}\033[0m: \033[32m{value}\033[0m" for key, value in dictionary.items()]))
+
 
 def __from_file(path: Path) -> List[str]:
     with open(path, mode='r', encoding='utf-8') as file_handler:
         return [line.rstrip() for line in file_handler.readlines() if line[0] != '#']
+
 
 def main():
     parser = argparse.ArgumentParser(prog=package_name)
@@ -25,9 +27,10 @@ def main():
     parser._optionals.title = 'Arguments'
 
     parser.add_argument('-v', '--version', action='version', version=f"%(prog)s {__version__}")
-    parser.add_argument('-V', '--verbose', default=True, action=argparse.BooleanOptionalAction, help="increase output verbosity")
-    parser.add_argument('-l', '--logging', default=True, action=argparse.BooleanOptionalAction, help="enable URL logging")
+    parser.add_argument('-V', '--verbose', default=False, action='store_true', help="increase output verbosity")
+    parser.add_argument('-l', '--logging', default=False, action='store_true', help="enable URL logging")
     parser.add_argument('-t', '--token', type=str, default='secret', help="configure an API token (optional)")
+    parser.add_argument('-a', '--user-agent', type=str, help="configure custom User-Agent")
 
     subparser = parser.add_subparsers(dest='command')
     upload_parser = subparser.add_parser('upload', help="upload a file to https://anonfiles.com")
@@ -40,7 +43,7 @@ def main():
     download_parser.add_argument('-u', '--url', nargs='*', type=str, help="one or more URLs to download")
     download_parser.add_argument('-f', '--batch-file', type=Path, nargs='?', help="file containing URLs to download, one URL per line")
     download_parser.add_argument('-p', '--path', type=Path, default=Path.cwd(), help="download directory (CWD by default)")
-    download_parser.add_argument('-c', '--check', default=True, action=argparse.BooleanOptionalAction, help="check for duplicates")
+    download_parser.add_argument('-c', '--check', default=False, action='store_true', help="check for duplicates")
 
     try:
         args = parser.parse_args()
@@ -48,6 +51,9 @@ def main():
 
         if args.command is None:
             raise UserWarning("missing a command")
+
+        if args.user_agent is not None:
+            anon.user_agent = args.user_agent
 
         if args.command == 'upload':
             for file in args.file:
@@ -75,7 +81,6 @@ def main():
                         print(f"File: {download(url).file_path}")
                 else:
                     print(f"File: {download(url).file_path}")
-
 
     except UserWarning as bad_human:
         print(f"error: {bad_human}")

--- a/src/anonfile/__init__.py
+++ b/src/anonfile/__init__.py
@@ -57,7 +57,7 @@ def main():
         if args.command == 'preview':
             for url in args.url:
                 preview = anon.preview(url)
-                values = ['online' if preview.status else 'offline', preview.file_path.name, preview.url.geturl(), preview.ddl, preview.id, f"{preview.size}B"]
+                values = ['online' if preview.status else 'offline', preview.file_path.name, preview.url.geturl(), preview.ddl.geturl(), preview.id, f"{preview.size}B"]
 
                 if args.verbose:
                     __print_dict(dict(zip(['Status', 'File Path', 'URL', 'DDL', 'ID', 'Size'], values)))

--- a/src/anonfile/__init__.py
+++ b/src/anonfile/__init__.py
@@ -27,10 +27,12 @@ def main():
     parser._optionals.title = 'Arguments'
 
     parser.add_argument('-v', '--version', action='version', version=f"%(prog)s {__version__}")
-    parser.add_argument('-V', '--verbose', default=False, action='store_true', help="increase output verbosity")
-    parser.add_argument('-l', '--logging', default=False, action='store_true', help="enable URL logging")
+    parser.add_argument('-V', '--verbose', default=True, action='store_true', help="increase output verbosity (default)")
+    parser.add_argument('--no-verbose', dest='verbose', action='store_false', help="run commands silently")
+    parser.add_argument('-l', '--logging', default=True, action='store_true', help="enable URL logging (default)")
+    parser.add_argument('--no-logging', dest='logging', action='store_false', help="disable all logging activities")
     parser.add_argument('-t', '--token', type=str, default='secret', help="configure an API token (optional)")
-    parser.add_argument('-a', '--user-agent', type=str, help="configure custom User-Agent")
+    parser.add_argument('-a', '--user-agent', type=str, help="configure custom User-Agent (optional)")
 
     subparser = parser.add_subparsers(dest='command')
     upload_parser = subparser.add_parser('upload', help="upload a file to https://anonfiles.com")
@@ -43,7 +45,8 @@ def main():
     download_parser.add_argument('-u', '--url', nargs='*', type=str, help="one or more URLs to download")
     download_parser.add_argument('-f', '--batch-file', type=Path, nargs='?', help="file containing URLs to download, one URL per line")
     download_parser.add_argument('-p', '--path', type=Path, default=Path.cwd(), help="download directory (CWD by default)")
-    download_parser.add_argument('-c', '--check', default=False, action='store_true', help="check for duplicates")
+    download_parser.add_argument('-c', '--check', default=True, action='store_true', help="check for duplicates (default)")
+    download_parser.add_argument('--no-check', dest='check', action='store_false', help="disable checking for duplicates")
 
     try:
         args = parser.parse_args()

--- a/src/anonfile/anonfile.py
+++ b/src/anonfile/anonfile.py
@@ -89,6 +89,10 @@ logger.addHandler(file_handler)
 
 @dataclass(frozen=True)
 class ParseResponse:
+    """
+    Data class that is primarily used as a structured return type for the upload,
+    preview and download methods.
+    """
     response: Response
     file_path: Path
     ddl: ParseResult
@@ -146,9 +150,35 @@ class ParseResponse:
         """
         return int(self.json['data']['file']['metadata']['size']['bytes'])
 
+    def __str__(self) -> str:
+        return str(self.name)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(ID={self.id})"
+
     #endregion
 
 class AnonFile:
+    """
+    The unofficial Python API for https://anonfiles.com.
+
+    Basic Usage
+    -----------
+
+    ```
+    from anonfile import AnonFile
+
+    anon = AnonFile()
+    preview = anon.preview('https://anonfiles.com/b7NaVd0cu3/topsecret_mkv')
+
+    # topsecret.mkv
+    print(preview)
+    ```
+
+    Docs
+    ----
+    See full documentation at <https://www.hentai-chan.dev/projects/anonfile>.
+    """
     _timeout = (5, 5)
     _total = 5
     _status_forcelist = [413, 429, 500, 502, 503, 504]
@@ -252,7 +282,7 @@ class AnonFile:
         Note
         ----
         Although `anonfile` offers unlimited bandwidth, uploads cannot exceed a
-        file size of 20GB in theory. Due to technical difficulties in the implementation
+        file size of 20GB in theory. Due to technical difficulties in the implementation,
         the upper cap occurs much earlier at around 500MB.
         """
         path = Path(path)

--- a/src/anonfile/anonfile.py
+++ b/src/anonfile/anonfile.py
@@ -184,10 +184,11 @@ class AnonFile:
     _status_forcelist = [413, 429, 500, 502, 503, 504]
     _backoff_factor = 1
     _user_agent = None
+    _proxies = None
 
     API = "https://api.anonfiles.com/"
 
-    __slots__ = ['endpoint', 'token', 'timeout', 'total', 'status_forcelist', 'backoff_factor', 'user_agent']
+    __slots__ = ['endpoint', 'token', 'timeout', 'total', 'status_forcelist', 'backoff_factor', 'user_agent', 'proxies']
 
     def __init__(self,
                  token: str="undefined",
@@ -195,13 +196,15 @@ class AnonFile:
                  total: int=_total,
                  status_forcelist: List[int]=_status_forcelist,
                  backoff_factor: int=_backoff_factor,
-                 user_agent: str=_user_agent) -> AnonFile:
+                 user_agent: str=_user_agent,
+                 proxies: dict=_proxies) -> AnonFile:
         self.token = token
         self.timeout = timeout
         self.total = total,
         self.status_forcelist = status_forcelist,
         self.backoff_factor = backoff_factor
         self.user_agent = user_agent
+        self.proxies = proxies
 
     @staticmethod
     def __progressbar_options(iterable, desc, unit, color: str="\033[32m", char='\u25CB', total=None, disable=False) -> dict:
@@ -249,7 +252,7 @@ class AnonFile:
         Returns the GET request encoded in `utf-8`. Adds proxies to this session
         on the fly if urllib is able to pick up the system's proxy settings.
         """
-        response = self.session.get(url, timeout=self.timeout, proxies=getproxies(), **kwargs)
+        response = self.session.get(url, timeout=self.timeout, proxies=self.proxies or getproxies(), **kwargs)
         response.encoding = 'utf-8'
         return response
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ def pytest_addoption(parser):
         help="Secret anonfiles.com API token."
     )
 
+
 def pytest_generate_tests(metafunc):
     if 'token' in metafunc.fixturenames:
         metafunc.parametrize('token', metafunc.config.getoption('token'))

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
 import hashlib
+import os
 import unittest
 from pathlib import Path
 
 from faker import Faker
 
-from src.anonfile import AnonFile
+from src.anonfile import AnonFile, get_logfile_path
 
 TOKEN = None
 
@@ -20,13 +21,29 @@ def md5_checksum(path: Path) -> str:
         return hashlib.md5(file_handler.read()).hexdigest()
 
 
-class TestAnonFile(unittest.TestCase):
-    def setUp(self):
-        chrome_ua = Faker().chrome(version_from=90, version_to=93, build_from=4400, build_to=4500)
-        self.anon = AnonFile(token=TOKEN, user_agent=chrome_ua) if TOKEN else AnonFile(user_agent=chrome_ua)
-        self.test_file = Path("tests/test.txt")
-        self.test_small_file = "https://anonfiles.com/93k5x1ucu0/test_txt"
-        self.test_med_file = "https://anonfiles.com/b7NaVd0cu3/topsecret_mkv"
+def init_anon() -> AnonFile:
+    chrome_ua = Faker().chrome(version_from=90, version_to=93, build_from=4400, build_to=4500)
+    return AnonFile(token=TOKEN, user_agent=chrome_ua) if TOKEN else AnonFile(user_agent=chrome_ua)
+
+
+def write_file(file: str, lines: list) -> Path:
+    with open(file, mode='w+') as file_handler:
+        file_handler.write('\n'.join(lines))
+        return Path(file)
+
+
+def remove_file(file: str) -> None:
+    Path(file).unlink() if Path(file).exists() else None
+
+
+class TestAnonFileLibrary(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.anon = init_anon()
+        cls.test_file = Path("tests/test.txt")
+        cls.test_small_file = "https://anonfiles.com/93k5x1ucu0/test_txt"
+        cls.test_med_file = "https://anonfiles.com/b7NaVd0cu3/topsecret_mkv"
+        cls.garbage = []
 
     def test_upload(self):
         upload = self.anon.upload(self.test_file, progressbar=True, enable_logging=True)
@@ -45,10 +62,52 @@ class TestAnonFile(unittest.TestCase):
         download = self.anon.download(self.test_small_file, progressbar=True, enable_logging=True)
         self.assertTrue(download.file_path.exists(), msg="Download not successful.")
         self.assertEqual(download.file_path.name, self.test_file.name, msg="Different file in download path detected.")
-        download.file_path.unlink()
+        self.garbage.append(download.file_path)
 
     def test_multipart_encoded_files(self):
         # use pre-computed checksum for faster unit tests
         download = self.anon.download(self.test_med_file, progressbar=True, enable_logging=True)
         self.assertEqual("06b6a6bea6ba82900d144d3b38c65347", md5_checksum(download.file_path), msg="MD5 hash is corrupted.")
-        download.file_path.unlink()
+        self.garbage.append(download.file_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        for file in cls.garbage:
+            remove_file(file)
+
+
+class TestAnonFileCLI(unittest.TestCase):
+    @classmethod
+    def setUp(cls):
+        cls.anon = init_anon()
+        cls.test_urls = [
+            "https://anonfiles.com/93k5x1ucu0/test_txt",
+            "https://anonfiles.com/n5j2O8G9u0/test_txt",
+            "https://anonfiles.com/93k5x1ucu0/test_txt",
+            "https://anonfiles.com/pdj2O8Gbud/test_txt",
+            "https://anonfiles.com/raj5OeGcu3/test_txt",
+            "https://anonfiles.com/t1jeOfG1u2/test_txt"
+        ]
+        cls.test_preview = cls.anon.preview("https://anonfiles.com/93k5x1ucu0/test_txt")
+        cls.batch_file = write_file('batch.txt', cls.test_urls)
+        cls.logfile = get_logfile_path()
+
+    def test_cli_download(self):
+        url = self.test_preview.url.geturl()
+        os.system("anonfile --logging download --url %s --no-check" % url)
+        self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {url!r}")
+
+    def test_cli_batch_download(self):
+        os.system("anonfile --verbose download --batch-file %s --no-check" % self.batch_file)
+        self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {self.batch_file!r}")
+
+    def test_cli_log(self):
+        print()
+        os.system("anonfile log --read")
+        self.assertTrue(self.logfile.exists(), msg=f"Error: no log file produced in {self.logfile!r}")
+
+    @classmethod
+    def tearDownClass(cls):
+        remove_file(cls.test_preview.file_path)
+        remove_file(cls.batch_file)
+        remove_file(cls.logfile)

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -65,11 +65,11 @@ class TestAnonFileLibrary(unittest.TestCase):
         self.assertEqual(download.file_path.name, self.test_file.name, msg="Different file in download path detected.")
         self.garbage.append(download.file_path)
 
-    # def test_multipart_encoded_files(self):
-    #     # use pre-computed checksum for faster unit tests
-    #     download = self.anon.download(self.test_med_file, progressbar=True, enable_logging=True)
-    #     self.assertEqual("06b6a6bea6ba82900d144d3b38c65347", md5_checksum(download.file_path), msg="MD5 hash is corrupted.")
-    #     self.garbage.append(download.file_path)
+    def test_multipart_encoded_files(self):
+        # use pre-computed checksum for faster unit tests
+        download = self.anon.download(self.test_med_file, progressbar=True, enable_logging=True)
+        self.assertEqual("06b6a6bea6ba82900d144d3b38c65347", md5_checksum(download.file_path), msg="MD5 hash is corrupted.")
+        self.garbage.append(download.file_path)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -81,12 +81,9 @@ class TestAnonFileCLI(unittest.TestCase):
     def setUp(cls):
         cls.anon = init_anon()
         cls.test_urls = [
-            "https://anonfiles.com/93k5x1ucu0/test_txt",
             "https://anonfiles.com/n5j2O8G9u0/test_txt",
-            "https://anonfiles.com/93k5x1ucu0/test_txt",
             "https://anonfiles.com/pdj2O8Gbud/test_txt",
-            "https://anonfiles.com/raj5OeGcu3/test_txt",
-            "https://anonfiles.com/t1jeOfG1u2/test_txt"
+            "https://anonfiles.com/n5j2O8G9u0/test_txt"
         ]
         cls.test_preview = cls.anon.preview("https://anonfiles.com/93k5x1ucu0/test_txt")
         cls.batch_file = write_file('batch.txt', cls.test_urls)
@@ -99,12 +96,12 @@ class TestAnonFileCLI(unittest.TestCase):
 
     def test_cli_batch_download(self):
         os.system("anonfile --verbose download --batch-file %s --no-check" % self.batch_file)
-        self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {self.batch_file!r}")
+        self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {str(self.batch_file)!r}")
 
     def test_cli_log(self):
         print()
         os.system("anonfile log --read")
-        self.assertTrue(self.logfile.exists(), msg=f"Error: no log file produced in {self.logfile!r}")
+        self.assertTrue(self.logfile.exists(), msg=f"Error: no log file produced in {str(self.logfile)!r}")
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -86,18 +86,17 @@ class TestAnonFileCLI(unittest.TestCase):
             "https://anonfiles.com/pdj2O8Gbud/test_txt",
             "https://anonfiles.com/n5j2O8G9u0/test_txt"
         ]
-        cls.test_preview = cls.anon.preview(random.choice(cls.test_urls))
+        cls.test_url = random.choice(cls.test_urls)
         cls.batch_file = write_file('batch.txt', cls.test_urls)
         cls.logfile = get_logfile_path()
 
     def test_cli_download(self):
-        url = self.test_preview.url.geturl()
-        call = subprocess.call("anonfile --verbose download --url %s --no-check" % url, shell=True)
-        self.assertEqual(call, 0, msg=f"Download failed for: {url!r}")
+        call = subprocess.call("anonfile --verbose download --url %s --no-check" % self.test_url, shell=True)
+        self.assertFalse(call, msg=f"Download failed for: {self.test_url!r}")
 
     def test_cli_batch_download(self):
         call = subprocess.call("anonfile --verbose --logging download --batch-file %s --no-check" % self.batch_file, shell=True)
-        self.assertEqual(call, 0, msg=f"Download failed for: {str(self.batch_file)!r}")
+        self.assertFalse(call, msg=f"Download failed for: {str(self.batch_file)!r}")
 
     def test_cli_log(self):
         print()
@@ -106,6 +105,5 @@ class TestAnonFileCLI(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        remove_file(cls.test_preview.file_path)
         remove_file(cls.batch_file)
         remove_file(cls.logfile)

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -92,17 +92,17 @@ class TestAnonFileCLI(unittest.TestCase):
 
     def test_cli_download(self):
         url = self.test_preview.url.geturl()
-        subprocess.call("anonfile --verbose download --url %s --no-check" % url, shell=True)
-        self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {url!r}")
+        call = subprocess.call("anonfile --verbose download --url %s --no-check" % url, shell=True)
+        self.assertEqual(call, 0, msg=f"Download failed for: {url!r}")
 
     def test_cli_batch_download(self):
-        subprocess.call("anonfile --verbose --logging download --batch-file %s --no-check" % self.batch_file, shell=True)
-        self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {str(self.batch_file)!r}")
+        call = subprocess.call("anonfile --verbose --logging download --batch-file %s --no-check" % self.batch_file, shell=True)
+        self.assertEqual(call, 0, msg=f"Download failed for: {str(self.batch_file)!r}")
 
     def test_cli_log(self):
         print()
-        subprocess.call("anonfile log --read", shell=True)
-        self.assertTrue(self.logfile.exists(), msg=f"Error: no log file produced in {str(self.logfile)!r}")
+        call = subprocess.call("anonfile log --read", shell=True)
+        self.assertTrue(self.logfile.exists() and (call == 0), msg=f"Error: no log file produced in {str(self.logfile)!r}")
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import os
+import random
 import unittest
 from pathlib import Path
 
@@ -85,7 +86,7 @@ class TestAnonFileCLI(unittest.TestCase):
             "https://anonfiles.com/pdj2O8Gbud/test_txt",
             "https://anonfiles.com/n5j2O8G9u0/test_txt"
         ]
-        cls.test_preview = cls.anon.preview("https://anonfiles.com/93k5x1ucu0/test_txt")
+        cls.test_preview = cls.anon.preview(random.choice(cls.test_urls))
         cls.batch_file = write_file('batch.txt', cls.test_urls)
         cls.logfile = get_logfile_path()
 

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -79,7 +79,7 @@ class TestAnonFileLibrary(unittest.TestCase):
 
 class TestAnonFileCLI(unittest.TestCase):
     @classmethod
-    def setUp(cls):
+    def setUpClass(cls):
         cls.anon = init_anon()
         cls.test_urls = [
             "https://anonfiles.com/n5j2O8G9u0/test_txt",

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -10,12 +10,15 @@ from src.anonfile import AnonFile
 
 TOKEN = None
 
+
 def test_option(token):
     TOKEN = token
+
 
 def md5_checksum(path: Path) -> str:
     with open(path, mode='rb') as file_handler:
         return hashlib.md5(file_handler.read()).hexdigest()
+
 
 class TestAnonFile(unittest.TestCase):
     def setUp(self):

--- a/tests/test_anonfile.py
+++ b/tests/test_anonfile.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import hashlib
-import os
 import random
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -65,11 +65,11 @@ class TestAnonFileLibrary(unittest.TestCase):
         self.assertEqual(download.file_path.name, self.test_file.name, msg="Different file in download path detected.")
         self.garbage.append(download.file_path)
 
-    def test_multipart_encoded_files(self):
-        # use pre-computed checksum for faster unit tests
-        download = self.anon.download(self.test_med_file, progressbar=True, enable_logging=True)
-        self.assertEqual("06b6a6bea6ba82900d144d3b38c65347", md5_checksum(download.file_path), msg="MD5 hash is corrupted.")
-        self.garbage.append(download.file_path)
+    # def test_multipart_encoded_files(self):
+    #     # use pre-computed checksum for faster unit tests
+    #     download = self.anon.download(self.test_med_file, progressbar=True, enable_logging=True)
+    #     self.assertEqual("06b6a6bea6ba82900d144d3b38c65347", md5_checksum(download.file_path), msg="MD5 hash is corrupted.")
+    #     self.garbage.append(download.file_path)
 
     @classmethod
     def tearDownClass(cls):
@@ -92,16 +92,16 @@ class TestAnonFileCLI(unittest.TestCase):
 
     def test_cli_download(self):
         url = self.test_preview.url.geturl()
-        os.system("anonfile --logging download --url %s --no-check" % url)
+        subprocess.call("anonfile --verbose download --url %s --no-check" % url, shell=True)
         self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {url!r}")
 
     def test_cli_batch_download(self):
-        os.system("anonfile --verbose download --batch-file %s --no-check" % self.batch_file)
+        subprocess.call("anonfile --verbose --logging download --batch-file %s --no-check" % self.batch_file, shell=True)
         self.assertTrue(self.test_preview.file_path.exists(), f"Download failed for: {str(self.batch_file)!r}")
 
     def test_cli_log(self):
         print()
-        os.system("anonfile log --read")
+        subprocess.call("anonfile log --read", shell=True)
         self.assertTrue(self.logfile.exists(), msg=f"Error: no log file produced in {str(self.logfile)!r}")
 
     @classmethod


### PR DESCRIPTION
- Change ddl return type from str to ParseResult
- Allow path parameters to be either of type str or Path

TODO:

- [x] Add CLI to unit tests
- [x] Upload online docs
