### PR TITLE
Update Python Version Matrix in CI Jobs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ 3.7 ]
+        python-version: [ '3.8' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
* Python version 3.7 end-of-life (EOL) is due on 27 June 2023
* Using version 3.8 as a new baseline for this projects also allows us to make use of this feature list:

  https://docs.python.org/3/whatsnew/3.8.html
  
Notice that the version numbers are all now enclosed in single quotes. This is important in special situations, without that version `3.10` will be interpreted as `3.1` by GitHub Actions (and rightly, so!). Therefore, it's considered best practice to treat version numbers as strings, since version numbers can come in all forms or shapes.