### PR TITLE
Fix StopIteration error after parsing a URL

### DIFF
--- a/src/anonfile/anonfile.py
+++ b/src/anonfile/anonfile.py
@@ -330,7 +330,7 @@ class AnonFile:
         ```
         """
         with self.__get(urljoin(AnonFile.API, f"v2/file/{urlparse(url).path.split('/')[1]}/info")) as response:
-            links = re.findall(r'''.*?href=['"](.*?)['"].*?''', html.unescape(self.__get(url).text), re.I)
+            links = re.findall(r'''.*?(?:href|value)=['"](.*?)['"].*?''', html.unescape(self.__get(url).text), re.I)
             ddl = urlparse(next(filter(lambda link: 'cdn-' in link, links)))
             file_path = Path(path).joinpath(Path(ddl.path).name)
             return ParseResponse(response, file_path, ddl)


### PR DESCRIPTION
When trying to download or preview a file that AnonFile detects as malware, anonfile-api does not match because it search between URLS of an href attribute, but the URL is of a value attribute.

AnonFile seems to scan a file when its size is probably <= 30 MiB. Sometimes it detects some files as malware, but I check them in VirusTotal and there is no problem. I think users who download such files should be their own responsible, so it should be downloaded without user intervention.

---

Of course, if downloading a file that appears to be malware (false positive or not) is a problem I think it is not difficult to throw an exception when an argument, say, `not_malware=True`, but such an argument should be passed as a CLI argument?